### PR TITLE
v3 warnings/exceptions

### DIFF
--- a/src/Transport/SendgridV3Transport.php
+++ b/src/Transport/SendgridV3Transport.php
@@ -183,6 +183,7 @@ class SendgridV3Transport extends Transport
      * @param Swift_Mime_Message $message
      * @param array $data
      * @return array
+     * @throws \Exception
      */
     protected function setParameters(Swift_Mime_Message $message, $data)
     {

--- a/src/Transport/SendgridV3Transport.php
+++ b/src/Transport/SendgridV3Transport.php
@@ -201,10 +201,26 @@ class SendgridV3Transport extends Transport
         }
 
         foreach ($smtp_api as $key => $val) {
-            if ($key === 'personalizations') {
-                $this->setPersonalizations($data, $val);
-                continue;
+
+            switch($key) {
+
+                case 'personalizations':
+                    $this->setPersonalizations($data, $val);
+                    continue 2;
+
+                case 'unique_args':
+                    throw new \Exception('Sendgrid v3 now uses custom_args instead of unique_args');
+
+                case 'custom_args':
+                    foreach($val as $name => $value) {
+                        if (!is_string($value)) {
+                            throw new \Exception('Sendgrid v3 custom arguments have to be a string.');
+                        }
+                    }
+                    break;
+
             }
+
             array_set($data, $key, $val);
         }
         return $data;


### PR DESCRIPTION
@eightyfive tagging you, because I'd like your feedback too and I'm guessing you're into improving this lib too.

First setup to help users that use v3, when embedding smpt-api params. 

- When coming from v2, the 'unique_args' attribute is now called 'custom_args'. However, unlike with the change from 'category' to 'categories' that gives an error response from Sendgrid, when using 'unique_args' in the payload, no error is given. But using unique_args no actual data will be set in Sendgrid. 

- When using the new 'custom_args', the values have to be strings. If you use for instance an integer, the api response from Sendgrid is an empty error message. So I figured we could warn users this way. I also considered automatically force typing to strings, but I think throwing exception is better.

- Right now throwing standard Exception, perhaps make that a specific exception?

- Also it's not checking that custom_args is an array, but that means the code will just fail when they don't make it an array. From the Sendgrid documentation it should be clear that is should be an array. But any thoughts on this are welcome.