### PR TITLE
Update SendGrid.php to work with Cached Config

### DIFF
--- a/src/SendGrid.php
+++ b/src/SendGrid.php
@@ -13,7 +13,7 @@ trait SendGrid
      */
     public function sendgrid($params)
     {
-        if ($this instanceof Mailable && env('MAIL_DRIVER') == "sendgrid") {
+        if ($this instanceof Mailable && config('mail.driver') == "sendgrid") {
             $this->withSwiftMessage(function (Swift_Message $message) use ($params) {
                 $message->embed(\Swift_Image::newInstance($params, 'sendgrid/x-smtpapi'));
             });


### PR DESCRIPTION
Per the 5.3 [upgrade guide](https://laravel.com/docs/5.3/upgrade), under Configuration - Caching and ENV, if you cache the configuration (as most do on production), you cannot access env values using env.  Instead, they are attached to the container, and can be accessed in this case via config('mail.driver').