### PR TITLE
Add the ability to override the API key from a message

### DIFF
--- a/src/Transport/SendgridTransport.php
+++ b/src/Transport/SendgridTransport.php
@@ -23,10 +23,12 @@ class SendgridTransport extends Transport
     private $options;
     private $attachments;
     private $numberOfRecipients;
+    private $apiKey;
 
     public function __construct(ClientInterface $client, $api_key)
     {
         $this->client = $client;
+        $this->apiKey = $api_key;
         $this->options = [
             'headers' => [
                 'Authorization' => 'Bearer ' . $api_key,
@@ -63,6 +65,8 @@ class SendgridTransport extends Transport
         $data = $this->setParameters($message, $data);
 
         $payload['json'] = $data;
+
+        array_set($payload, 'headers.Authorization', 'Bearer ' . $this->apiKey);
 
         $response = $this->post($payload);
 
@@ -242,6 +246,10 @@ class SendgridTransport extends Transport
         foreach ($smtp_api as $key => $val) {
 
             switch ($key) {
+
+                case 'api_key':
+                    $this->apiKey = $val;
+                    continue 2;
 
                 case 'personalizations':
                     $this->setPersonalizations($data, $val);


### PR DESCRIPTION
Hi there. First, thanks so much for the super-useful package!

I've run into a case where I sometimes need to be able to override the API key depending on the `Mailable` that I'm sending. This is because I need to be able to send from multiple different domains. In order to cleanly separate the domains, I'd like to use sub-accounts to keep things neat.

This would allow a message to use the `sendgrid` or `embedData` methods to add an `api_key` item along with personalizations, etc. that would get injected into the Authorization header at the time of sending.