### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ $ composer require s-ichikawa/laravel-sendgrid-driver
 ```
 
 Add the sendgrid service provider in config/app.php:
+(Laravel 5.5+ uses Package Auto-Discovery, so doesn't require you to manually add the ServiceProvider.)
 ```php
 'providers' => [
     Sichikawa\LaravelSendgridDriver\SendgridTransportServiceProvider::class


### PR DESCRIPTION
Hi, s-ichikawa

From Laravel5.5, there is no require you to manually add the ServiceProvider. 

I  was checked on Laravel 5.7 without adding the ServiceProvider, working properly. 

### ref
https://laravel-news.com/package-auto-discovery
https://medium.com/peeredcamp/sending-mails-with-sendgrid-in-laravel-apps-a91297ffddea
https://github.com/barryvdh/laravel-debugbar


