### PR TITLE
Update soon-to-be deprecated Laravel array_get function calls in tests

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Arr;
+
 class TestCase extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -48,7 +50,7 @@ class MockConfig implements ArrayAccess, Illuminate\Contracts\Config\Repository
      */
     public function get($key, $default = null)
     {
-        return array_get($this->item, $key, $default);
+        return Arr::get($this->item, $key, $default);
     }
 
     /**

--- a/tests/Transport/SendgridTransportTest.php
+++ b/tests/Transport/SendgridTransportTest.php
@@ -2,6 +2,7 @@
 
 use GuzzleHttp\Client as HttpClient;
 use Illuminate\Mail\Message;
+use Illuminate\Support\Arr;
 use Sichikawa\LaravelSendgridDriver\Transport\SendgridTransport;
 
 class SendgridTransportTest extends TestCase
@@ -148,12 +149,12 @@ class SendgridTransportTest extends TestCase
 
         $res = $getPersonalizations($message);
 
-        $this->assertEquals($to, array_get($res, '0.to.0.email'));
-        $this->assertEquals($to_name, array_get($res, '0.to.0.name'));
-        $this->assertEquals($cc, array_get($res, '0.cc.0.email'));
-        $this->assertEquals($cc_name, array_get($res, '0.cc.0.name'));
-        $this->assertEquals($bcc, array_get($res, '0.bcc.0.email'));
-        $this->assertEquals($bcc_name, array_get($res, '0.bcc.0.name'));
+        $this->assertEquals($to, Arr::get($res, '0.to.0.email'));
+        $this->assertEquals($to_name, Arr::get($res, '0.to.0.name'));
+        $this->assertEquals($cc, Arr::get($res, '0.cc.0.email'));
+        $this->assertEquals($cc_name, Arr::get($res, '0.cc.0.name'));
+        $this->assertEquals($bcc, Arr::get($res, '0.bcc.0.email'));
+        $this->assertEquals($bcc_name, Arr::get($res, '0.bcc.0.name'));
     }
 
     public function testGetContents()
@@ -168,10 +169,10 @@ class SendgridTransportTest extends TestCase
         )]);
 
         $res = $getContents($message->getSwiftMessage());
-        $this->assertEquals('text/plain', array_get($res, '0.type'));
-        $this->assertEquals('This is a test.', array_get($res, '0.value'));
-        $this->assertEquals('text/html', array_get($res, '1.type'));
-        $this->assertEquals('Test body.', array_get($res, '1.value'));
+        $this->assertEquals('text/plain', Arr::get($res, '0.type'));
+        $this->assertEquals('This is a test.', Arr::get($res, '0.value'));
+        $this->assertEquals('text/html', Arr::get($res, '1.type'));
+        $this->assertEquals('Test body.', Arr::get($res, '1.value'));
     }
 
     public function testGetAttachments()
@@ -186,8 +187,8 @@ class SendgridTransportTest extends TestCase
         $message->attach($file);
 
         $res = $getAttachment($message->getSwiftMessage());
-        $this->assertEquals(base64_encode(file_get_contents($file)), array_get($res, '0.content'));
-        $this->assertEquals('test.png', array_get($res, '0.filename'));
+        $this->assertEquals(base64_encode(file_get_contents($file)), Arr::get($res, '0.content'));
+        $this->assertEquals('test.png', Arr::get($res, '0.filename'));
     }
 
     public function testSetParameters()
@@ -284,7 +285,7 @@ class SendgridTransportTest extends TestCase
         $transport->send($message->getSwiftMessage());
 
         /** @var \GuzzleHttp\Psr7\Request $request */
-        $request = array_get($container, '0.request');
+        $request = Arr::get($container, '0.request');
         $this->assertEquals('Bearer ' . $this->api_key, $request->getHeaderLine('Authorization'));
         $this->assertNotContains('"api_key":', (string)$request->getBody());
     }


### PR DESCRIPTION
Laravel will be deprecating use of the `array_*` helpers that they provide. These will be called via `Arr::*` starting in Laravel 6.

From https://github.com/illuminate/support/blob/5.8/helpers.php:
```
if (! function_exists('array_get')) {
    /**
     * Get an item from an array using "dot" notation.
     *
     * @param  \ArrayAccess|array  $array
     * @param  string  $key
     * @param  mixed   $default
     * @return mixed
     *
     * @deprecated Arr::get() should be used directly instead. Will be removed in Laravel 6.0.
     */
    function array_get($array, $key, $default = null)
    {
        return Arr::get($array, $key, $default);
    }
```

Tests passing locally:
![image](https://user-images.githubusercontent.com/14229549/62725014-44d3f600-b9e2-11e9-8a14-c697360b587e.png)
