### PR TITLE
Cleanup dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,15 +5,15 @@
     "license": "MIT",
     "require": {
         "illuminate/mail": ">=7.0",
-        "guzzlehttp/guzzle": "^6.3 || ^7.0",
-        "phpoption/phpoption": "^1.7",
-        "vlucas/phpdotenv": "^4.1"
+        "illuminate/support": ">=7.0",
+        "guzzlehttp/guzzle": "^6.3 || ^7.0"
     },
     "require-dev": {
         "illuminate/container": ">=7.0",
         "illuminate/filesystem": ">=7.0",
         "phpunit/phpunit": "^8.5",
-        "laravel/helpers": "^1.2"
+        "laravel/helpers": "^1.2",
+        "vlucas/phpdotenv": "^4.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hello 👋

This PR changes some of the dependencies of this package to reduce unnecessary production dependencies.

- `illuminate/support` should be required because it's [required by the service provider](https://github.com/s-ichikawa/laravel-sendgrid-driver/blob/b04c2f3446d07560ba154b62cb4a62626d6c35d6/src/SendgridTransportServiceProvider.php#L7) and the [`SendGridTransport`](https://github.com/s-ichikawa/laravel-sendgrid-driver/blob/master/src/Transport/SendgridTransport.php#L8).
- `phpoption/phpoption` doesn't need to be required directly because it's only used by `vlucas/phpdotenv`.
- `vlucas/phpdotenv` can be moved to `require-dev` because it's only used directly by this package in tests.