### PR TITLE
Update `vlucas/phpdotenv` dependency to support Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "illuminate/filesystem": ">=7.0",
         "phpunit/phpunit": "^8.5",
         "laravel/helpers": "^1.2",
-        "vlucas/phpdotenv": "^4.1"
+        "vlucas/phpdotenv": "^4.1 || ^5.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I've updated the `vlucas/phpdotenv` dependency requirement to allow version 5.2 so the package can be used with Laravel 8.