### PR TITLE
Add sendgrid message id to transport & support laravel 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 vendor
 composer.lock
+
+.idea/
+
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         "guzzlehttp/guzzle": "^7.2"
     },
     "require-dev": {
-        "illuminate/container": "^9.0",
-        "illuminate/filesystem": "^9.0",
+        "illuminate/container": "^9.0||^10.0",
+        "illuminate/filesystem": "^9.0||^10.0",
         "phpunit/phpunit": "^9.5.8",
         "laravel/helpers": "^1.2",
         "vlucas/phpdotenv": "^5.4.1"

--- a/src/Transport/SendgridTransport.php
+++ b/src/Transport/SendgridTransport.php
@@ -83,8 +83,12 @@ class SendgridTransport extends AbstractTransport
             ],
             'json' => $data,
         ];
+    
+        $response = $this->post($payload);
 
-        $this->post($payload);
+        $message->getOriginalMessage()
+            ->getHeaders()
+            ->addTextHeader('X-Sendgrid-Message-Id', $response->getHeaderLine('X-Message-Id'));
     }
 
     /**

--- a/tests/Transport/SendgridTransportTest.php
+++ b/tests/Transport/SendgridTransportTest.php
@@ -3,11 +3,13 @@
 namespace Transport;
 
 use GuzzleHttp\Client;
+use Illuminate\Support\Str;
 use Sichikawa\LaravelSendgridDriver\SendGrid;
 use Sichikawa\LaravelSendgridDriver\Transport\SendgridTransport;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
-use Symfony\Component\Mime\Part\TextPart;
 
 class SendgridTransportTest extends \TestCase
 {
@@ -99,6 +101,37 @@ class SendgridTransportTest extends \TestCase
                 'value' => '<body>test body</body>'
             ],
         ], $result);
+    }
+
+    public function testXMessageID()
+    {
+        $client = $this->getMockBuilder(\GuzzleHttp\Client::class)
+            ->onlyMethods(['request'])
+            ->getMock();
+
+        $client->expects($this->once())
+            ->method('request')
+            ->willReturn(new \GuzzleHttp\Psr7\Response(200, [
+                'X-Message-ID' => $messageId = Str::random(32),
+            ]));
+
+        $transport = new SendgridTransport($client, $this->api_key);
+        $reflection = new \ReflectionClass($this->transport);
+
+        $email = (new Email())
+            ->text('test body')
+            ->html('<body>test body</body>')
+            ->to(new Address('to@sink.sendgrid.net', 'test_to'))
+            ->from(new Address('from@sink.sendgrid.net', 'test_from'));
+
+        $send = new SentMessage($email, Envelope::create($email));
+
+        $method = $reflection->getMethod('doSend');
+        $method->setAccessible(true);
+
+        $method->invoke($transport, $send);
+
+        $this->assertEquals($messageId, $email->getHeaders()->getHeaderBody('X-Sendgrid-Message-ID'));
     }
 
     public function testGetReplyTo()


### PR DESCRIPTION
## WHAT
Added X-Sendgird-Message-ID to the header of the email.

## WHY
This was in the previous version for laravel 8. It also provides a way to match emails from incoming webhooks using the message id.
