### PR TITLE
Set X-Message-Id with SentMessage::setMessageId 

### DIFF
--- a/src/Transport/SendgridTransport.php
+++ b/src/Transport/SendgridTransport.php
@@ -87,7 +87,13 @@ class SendgridTransport extends AbstractTransport implements Stringable
 
         $response = $this->post($payload);
 
-        $message->setMessageId($response->getHeaderLine('X-Message-Id'));
+        $messageId = $response->getHeaderLine('X-Message-Id');
+
+        $message->setMessageId($messageId);
+
+        $message->getOriginalMessage()
+            ->getHeaders()
+            ->addTextHeader('X-Sendgrid-Message-Id', $messageId);
     }
 
     /**

--- a/src/Transport/SendgridTransport.php
+++ b/src/Transport/SendgridTransport.php
@@ -87,9 +87,7 @@ class SendgridTransport extends AbstractTransport implements Stringable
 
         $response = $this->post($payload);
 
-        $message->getOriginalMessage()
-            ->getHeaders()
-            ->addTextHeader('X-Sendgrid-Message-Id', $response->getHeaderLine('X-Message-Id'));
+        $message->setMessageId($response->getHeaderLine('X-Message-Id'));
     }
 
     /**

--- a/tests/Transport/SendgridTransportTest.php
+++ b/tests/Transport/SendgridTransportTest.php
@@ -131,7 +131,7 @@ class SendgridTransportTest extends \TestCase
 
         $method->invoke($transport, $send);
 
-        $this->assertEquals($messageId, $email->getHeaders()->getHeaderBody('X-Sendgrid-Message-ID'));
+        $this->assertEquals($messageId, $send->getMessageId());
     }
 
     public function testGetReplyTo()

--- a/tests/Transport/SendgridTransportTest.php
+++ b/tests/Transport/SendgridTransportTest.php
@@ -132,6 +132,8 @@ class SendgridTransportTest extends \TestCase
         $method->invoke($transport, $send);
 
         $this->assertEquals($messageId, $send->getMessageId());
+
+        $this->assertEquals($messageId, $email->getHeaders()->getHeaderBody('X-Sendgrid-Message-ID'));
     }
 
     public function testGetReplyTo()


### PR DESCRIPTION
## WHAT
Propose using `setMessageId()` instead of headers for `X-Message-Id` 

## WHY
```php
Event::listen(function (MessageSent $event) {
    // when sendgrid ID set with headers
    $sendgridId = $event->message->getHeaders()->getHeaderBody('x-sendgrid-message-id');

    // when sendgrid ID set with setMessageId()
    $sendgridId = $event->sent->getMessageId();
});
```
