### PR TITLE
Fix for disposition for inline attachments.

### DIFF
--- a/src/Transport/SendgridTransport.php
+++ b/src/Transport/SendgridTransport.php
@@ -201,7 +201,7 @@ class SendgridTransport extends AbstractTransport implements Stringable
                 'content' => base64_encode($attachment->getBody()),
                 'filename' => $this->getAttachmentName($attachment),
                 'type' => $this->getAttachmentContentType($attachment),
-                'disposition' => $attachment->getPreparedHeaders()->getHeaderParameter('Parameterized', 'Content-Disposition'),
+                'disposition' => $attachment->getDisposition(),
                 'content_id' => $attachment->getContentId(),
             ];
         }


### PR DESCRIPTION
Inline attachments did not work with the old code, the disposition field always returned null.

Using $attachment->getDisposition(); works.