### PR TITLE
Fix: Ensure content_id consistency with Laravel Mailer for inline attachments

### DIFF
--- a/src/Transport/SendgridTransport.php
+++ b/src/Transport/SendgridTransport.php
@@ -206,7 +206,7 @@ class SendgridTransport extends AbstractTransport implements Stringable
                 'filename' => $this->getAttachmentName($attachment),
                 'type' => $this->getAttachmentContentType($attachment),
                 'disposition' => $attachment->getDisposition(),
-                'content_id' => $attachment->getContentId(),
+                'content_id' => $this->getAttachmentName($attachment),
             ];
         }
         return $attachments;


### PR DESCRIPTION
Description

This PR addresses an issue where inline images embedded in emails sent via the laravel-sendgrid-driver do not display correctly in Gmail. The root cause is a mismatch between the Content-ID assigned to the inline attachment and the cid used in the email’s HTML.

Problem
	•	Laravel Mailer uses a custom cid for inline attachments generated by $message->embed() instead of the Content-ID generated by Symfony Mailer.
	•	The mismatch breaks the cid reference in Gmail, causing inline images to fail to render, even though they work in other email clients (e.g., Outlook).

Solution
	•	Update the SendgridTransport.php file to use Laravel’s attachment name as the content_id for inline attachments.
	•	This ensures consistency between the Content-ID and the cid reference, resolving the rendering issue in Gmail.