### PR TITLE
Make `SendgridTransport::post()` protected

### DIFF
--- a/src/Transport/SendgridTransport.php
+++ b/src/Transport/SendgridTransport.php
@@ -283,7 +283,7 @@ class SendgridTransport extends AbstractTransport implements Stringable
      * @return ResponseInterface
      * @throws ClientException
      */
-    private function post($payload)
+    protected function post($payload)
     {
         return $this->client->request('POST', $this->endpoint, $payload);
     }


### PR DESCRIPTION
## WHAT
This makes the method `post()` protected.

## WHY
I want to use Laravel's Http facade rather than Guzzle. This allows for greater testability. We can easily extend this class and modify the method.
