### PR TITLE
Fix PHP 8.4 implicitly nullable parameter deprecation

### DIFF
--- a/src/Transport/SendgridTransport.php
+++ b/src/Transport/SendgridTransport.php
@@ -42,7 +42,7 @@ class SendgridTransport extends AbstractTransport implements Stringable
     private $apiKey;
     private $endpoint;
 
-    public function __construct(ClientInterface $client, string $api_key, string $endpoint = null)
+    public function __construct(ClientInterface $client, string $api_key, ?string $endpoint = null)
     {
         $this->client = $client;
         $this->apiKey = $api_key;


### PR DESCRIPTION
## WHAT

Fix PHP 8.4 implicitly nullable parameter deprecation

## WHY

I use Laravel 12 on PHP8.4. And so PHP 8.4 is deprecated feature [`Implicitly nullable parameter` https://www.php.net/manual/en/migration84.deprecated.php](https://www.php.net/manual/en/migration84.deprecated.php).

