### PR TITLE
Update content_id to use $attachment->getContentId method

### DIFF
--- a/src/Transport/SendgridTransport.php
+++ b/src/Transport/SendgridTransport.php
@@ -206,7 +206,7 @@ class SendgridTransport extends AbstractTransport implements Stringable
                 'filename' => $this->getAttachmentName($attachment),
                 'type' => $this->getAttachmentContentType($attachment),
                 'disposition' => $attachment->getDisposition(),
-                'content_id' => $this->getAttachmentName($attachment),
+                'content_id' => $attachment->getContentId(),
             ];
         }
         return $attachments;


### PR DESCRIPTION
Relates: #181

The way content_id is referenced, changed in laravel 12.x. See: 
https://github.com/laravel/framework/pull/57726
https://github.com/laravel/framework/pull/58173

The inconsistency between content ids, as described in #181, has been fixed and it is now required again to use $attachment->getContentId().

